### PR TITLE
Improve hashing performance

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -8,16 +8,18 @@ import 'dart:typed_data';
 
 /// Reads a 32-bit little-endian integer from the specified buffer at the
 /// specified byte offset. (If unspecified, [byteOffset] is 0 which means the
-// /// value is read from the start of the buffer.)
-int readLE32(Uint8List value, [int byteOffset = 0]) {
-  return ByteData.sublistView(value).getUint32(byteOffset, Endian.little);
+/// value is read from the start of the buffer.)
+@pragma('vm:prefer-inline')
+int readLE32(ByteData bd, [int byteOffset = 0]) {
+  return bd.getUint32(byteOffset, Endian.little);
 }
 
 /// Reads a 64-bit little-endian integer from the specified buffer at the
 /// specified byte offset. (If unspecified, [byteOffset] is 0 which means the
 /// value is read from the start of the buffer.)
-int readLE64(Uint8List value, [int byteOffset = 0]) {
-  return ByteData.sublistView(value).getUint64(byteOffset, Endian.little);
+@pragma('vm:prefer-inline')
+int readLE64(ByteData bd, [int byteOffset = 0]) {
+  return bd.getUint64(byteOffset, Endian.little);
 }
 
 //
@@ -35,7 +37,7 @@ class PairInt {
 /// Multiplies the 64-bit integers stored in [lhs] and [rhs] (bitwise) and
 /// stores the result in a 128-bit integer in the form of a [PairInt].
 PairInt mult64to128(int lhs, int rhs) {
-  int loLo = (lhs.toUnsigned(32) * rhs.toUnsigned(32)).toUnsigned(64);
+  int loLo = lhs.toUnsigned(32) * rhs.toUnsigned(32);
   int hiLo = (lhs >>> 32) * rhs.toUnsigned(32);
   int loHi = lhs.toUnsigned(32) * (rhs >>> 32);
   int hiHi = (lhs >>> 32) * (rhs >>> 32);

--- a/test/xxh3_benchmark.dart
+++ b/test/xxh3_benchmark.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:xxh3/xxh3.dart';
+
+void main(List<String> args) {
+  final bytes =
+      args.isEmpty ? Uint8List(64 * 1024) : File(args.first).readAsBytesSync();
+
+  for (var j = 0; j < 2; j++) {
+    final N = 5000;
+    final sw = Stopwatch()..start();
+    for (var i = 0; i < N; i++) {
+      xxh3(bytes);
+    }
+    final totalNs = sw.elapsedMicroseconds * 1000;
+    final nsPerIteration = totalNs / N;
+    final nsPerByte = nsPerIteration / bytes.lengthInBytes;
+
+    print('$nsPerByte ns/byte');
+  }
+}


### PR DESCRIPTION
The improvement is in the range of ~10-20x depending
on platform and compilation mode, e.g. on my M1 MacBook Pro
AOT mode goes from 6ns/byte to 0.3ns/byte and JIT mode goes
from 5ns/byte to 0.4ns/byte.

The bulk of the improvement comes from avoiding allocating
a temporary ByteData for every readLE64. While it might
be reasonable to expect this allocation to be eliminated
Dart VM compiler is currently unable to do that for several
reasons (most of which can be easily fixed).

The second part of the win comes from avoiding boxed List
type for accumulator and using Int64List instead.

Additionally JIT compiler trips over `toUnsigned(64)` which
should be a no-op but instead hits a suboptimal implementation
of out of range left shift (1 << 64) and falls over fast path, so I
removed that as well.
